### PR TITLE
Address sass deprecation warning

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,10 +22,4 @@ import configs from "@8hobbies/eslint-conf-react-baseline";
 const reactConfig = configs.recommended(import.meta.dirname, true);
 reactConfig[reactConfig.length - 1].files = ["src/*.ts", "src/*.tsx"];
 
-export default [
-  {
-    ignores: ["./types/"],
-  },
-  ...baseConfigs.recommended,
-  ...reactConfig,
-];
+export default [...baseConfigs.recommended, ...reactConfig];

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,13 @@ function generateManifest() {
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  css: {
+    preprocessorOptions: {
+      scss: {
+        api: "modern-compiler",
+      },
+    },
+  },
   plugins: [
     react(),
     webExtension({


### PR DESCRIPTION
> Deprecation [legacy-js-api]: The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.