### PR TITLE
Change host_permissions to <all_urls>

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -13,7 +13,7 @@
   "minimum_chrome_version": "128",
   "options_page": "src/options.html",
   "permissions": ["storage", "scripting"],
-  "optional_host_permissions": ["<all_urls>"],
+  "host_permissions": ["<all_urls>"],
   "browser_specific_settings": {
     "gecko": {
       "id": "plausible-shield@goodaddon.com",


### PR DESCRIPTION
Seems like using `optional_host_permissions` does not allow browsers to sync permissions granted to individual browser instances, which in some sense defeats the purposes of this extension because this extension won't be activated on the required URLs. Using `host_permissions` should be OK because security/privacy-aware users can change what sites are allowed in extension details page.

Should the demand arise, we can build a optional_host_permissions version.