### PR TITLE
Explain that browser needs restart when plausible is first synced in

### DIFF
--- a/descriptions/text.mdx
+++ b/descriptions/text.mdx
@@ -15,6 +15,9 @@ would like to shield from, and Plausible Shield:
   [Firefox Sync](https://www.mozilla.org/en-US/firefox/features/sync/), or a similar feature from
   another browser.
 
+**If Plausible Shield is synced for the first time to a new browser instance, you may need to
+restart the browser to take effects.**
+
 ## Screenshots
 
 ### Extension Settings


### PR DESCRIPTION
chrome.storage.onChanged may not be triggered the first time the extension data is synced in.

https://stackoverflow.com/questions/79256270/is-chrome-storage-onchanged-event-triggered-when-the-sync-storage-is-synced-in