### PR TITLE
Disable annoying spell check in the URL prefixes input box

### DIFF
--- a/descriptions/text.mdx
+++ b/descriptions/text.mdx
@@ -39,6 +39,11 @@ line at the top of the console:
 
 ## Changelog
 
+### v0.2.1
+
+- Disable annoying spell check in the URL prefixes input box, since legitimately spelled URLs in
+  most cases do not pass spell checks.
+
 ### v0.2.0
 
 - Fix a sync-related permission annoyance.

--- a/src/OptionsApp.test.tsx
+++ b/src/OptionsApp.test.tsx
@@ -57,6 +57,19 @@ describe("Options page", () => {
     });
   });
 
+  test("URL prefixes text area has disabled spell check", async () => {
+    render(<App />);
+
+    await waitFor(() => {
+      expect(getUrlPrefixesTextAreaElement()).toBeEnabled();
+    });
+
+    expect(getUrlPrefixesTextAreaElement()).toHaveAttribute("spellcheck");
+    expect(getUrlPrefixesTextAreaElement().getAttribute("spellcheck")).toBe(
+      "false",
+    );
+  });
+
   describe("URL Prefixes text area loads previous save", () => {
     for (const testCase of [
       {

--- a/src/OptionsApp.tsx
+++ b/src/OptionsApp.tsx
@@ -158,6 +158,11 @@ export default function App(): React.JSX.Element {
             }}
             fullWidth
             multiline
+            slotProps={{
+              htmlInput: {
+                spellCheck: "false",
+              },
+            }}
             error={urlPrefixesHelperText !== null}
             helperText={urlPrefixesHelperText}
             sx={{


### PR DESCRIPTION
Since legitimately spelled URLs in most cases do not pass spell checks.