### PR TITLE
Load settings upon installed

### DIFF
--- a/descriptions/text.mdx
+++ b/descriptions/text.mdx
@@ -39,6 +39,10 @@ line at the top of the console:
 
 ## Changelog
 
+### v0.2.2
+
+- Also load settings right after installed, otherwise synced installation may not load the settings until the browser restarts.
+
 ### v0.2.1
 
 - Disable annoying spell check in the URL prefixes input box, since legitimately spelled URLs in

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Plausible Shield",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Plausible Shield",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@8hobbies/utils": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "Plausible Shield",
   "description": "Automatically shield your browser from Plausible tracking from your websites",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "scripts": {
     "compile": "tsc",

--- a/src/background.ts
+++ b/src/background.ts
@@ -48,6 +48,13 @@ chrome.runtime.onInstalled.addListener(async (details) => {
     await chrome.tabs.create({
       url: "https://www.goodaddon.com/plausible-shield/",
     });
+
+    // This install may be a synced install. In a synced install, the storage seems to be synced
+    // together with the extension itself, and the storage change event does not take place.
+    const urlPrefixes = await loadUrlPrefixes();
+    if (urlPrefixes !== null) {
+      await registerContentScripts(urlPrefixes);
+    }
   } else if (details.reason === chrome.runtime.OnInstalledReason.UPDATE) {
     await chrome.tabs.create({
       url: "https://www.goodaddon.com/plausible-shield/#changelog",


### PR DESCRIPTION
In a synced install, the storage seems to be synced together with the extension itself, and the storage change event does not take place.